### PR TITLE
新規投稿ステップ3の実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -153,13 +153,244 @@ class PostsController < ApplicationController
 
   # 2巻の修行手順登録用
   def step3
-    @selected_chapter1_remarks = session[:chapter1_remarks]
+    @post_form_step3 = PostFormStep3.new
+    @now_chapter = Chapter.second
+    @turns = Turn.all
+    @actions = Action.all
+    @flower_seeds = FlowerSeed.all
+    @selected_support_characters = Character.find(session[:support_characters])
+    @farm_places = FarmPlace.all
   end
 
-  def create_step3; end
+  def create_step3
+    @post_form_step3 = PostFormStep3.new(post_form_step3_params)
+    @now_chapter = Chapter.second
+    @turns = Turn.all
+    @actions = Action.all
+    @flower_seeds = FlowerSeed.all
+    @selected_support_characters = Character.find(session[:support_characters])
+    @farm_places = FarmPlace.all
+    if @post_form_step3.valid?
+      # チャプター2行動選択用
+      session[:chapter2_actions] = [
+        @post_form_step3.first_day_action,
+        @post_form_step3.second_day_action,
+        @post_form_step3.third_day_action,
+        @post_form_step3.fourth_day_action,
+        @post_form_step3.fifth_day_action,
+        @post_form_step3.sixth_day_action,
+        @post_form_step3.seventh_day_action,
+        @post_form_step3.eighth_day_action
+      ]
+      # チャプター2備考欄用
+      session[:chapter2_remarks] = [
+        @post_form_step3.first_day_remark,
+        @post_form_step3.second_day_remark,
+        @post_form_step3.third_day_remark,
+        @post_form_step3.fourth_day_remark,
+        @post_form_step3.fifth_day_remark,
+        @post_form_step3.sixth_day_remark,
+        @post_form_step3.seventh_day_remark,
+        @post_form_step3.eighth_day_remark
+      ]
+      # チャプター2畑1の種用
+      session[:chapter2_farm1_seeds] = [
+        @post_form_step3.day1_farm1_seed,
+        @post_form_step3.day2_farm1_seed,
+        @post_form_step3.day3_farm1_seed,
+        @post_form_step3.day4_farm1_seed,
+        @post_form_step3.day5_farm1_seed,
+        @post_form_step3.day6_farm1_seed,
+        @post_form_step3.day7_farm1_seed,
+        @post_form_step3.day8_farm1_seed
+      ]
+      # チャプター2畑1の設置キャラクター用
+      session[:chapter2_farm1_characters] = [
+        @post_form_step3.day1_farm1_character,
+        @post_form_step3.day2_farm1_character,
+        @post_form_step3.day3_farm1_character,
+        @post_form_step3.day4_farm1_character,
+        @post_form_step3.day5_farm1_character,
+        @post_form_step3.day6_farm1_character,
+        @post_form_step3.day7_farm1_character,
+        @post_form_step3.day8_farm1_character
+      ]
+      # チャプター2畑2の種用
+      session[:chapter2_farm2_seeds] = [
+        @post_form_step3.day1_farm2_seed,
+        @post_form_step3.day2_farm2_seed,
+        @post_form_step3.day3_farm2_seed,
+        @post_form_step3.day4_farm2_seed,
+        @post_form_step3.day5_farm2_seed,
+        @post_form_step3.day6_farm2_seed,
+        @post_form_step3.day7_farm2_seed,
+        @post_form_step3.day8_farm2_seed
+      ]
+      # チャプター2畑2の設置キャラクター用
+      session[:chapter2_farm2_characters] = [
+        @post_form_step3.day1_farm2_character,
+        @post_form_step3.day2_farm2_character,
+        @post_form_step3.day3_farm2_character,
+        @post_form_step3.day4_farm2_character,
+        @post_form_step3.day5_farm2_character,
+        @post_form_step3.day6_farm2_character,
+        @post_form_step3.day7_farm2_character,
+        @post_form_step3.day8_farm2_character
+      ]
+      # チャプター2畑3の種用
+      session[:chapter2_farm3_seeds] = [
+        @post_form_step3.day1_farm3_seed,
+        @post_form_step3.day2_farm3_seed,
+        @post_form_step3.day3_farm3_seed,
+        @post_form_step3.day4_farm3_seed,
+        @post_form_step3.day5_farm3_seed,
+        @post_form_step3.day6_farm3_seed,
+        @post_form_step3.day7_farm3_seed,
+        @post_form_step3.day8_farm3_seed
+      ]
+      # チャプター2畑3の設置キャラクター用
+      session[:chapter2_farm3_characters] = [
+        @post_form_step3.day1_farm3_character,
+        @post_form_step3.day2_farm3_character,
+        @post_form_step3.day3_farm3_character,
+        @post_form_step3.day4_farm3_character,
+        @post_form_step3.day5_farm3_character,
+        @post_form_step3.day6_farm3_character,
+        @post_form_step3.day7_farm3_character,
+        @post_form_step3.day8_farm3_character
+      ]
+      # チャプター2畑4の種用
+      session[:chapter2_farm4_seeds] = [
+        @post_form_step3.day1_farm4_seed,
+        @post_form_step3.day2_farm4_seed,
+        @post_form_step3.day3_farm4_seed,
+        @post_form_step3.day4_farm4_seed,
+        @post_form_step3.day5_farm4_seed,
+        @post_form_step3.day6_farm4_seed,
+        @post_form_step3.day7_farm4_seed,
+        @post_form_step3.day8_farm4_seed
+      ]
+      # チャプター2畑4の設置キャラクター用
+      session[:chapter2_farm4_characters] = [
+        @post_form_step3.day1_farm4_character,
+        @post_form_step3.day2_farm4_character,
+        @post_form_step3.day3_farm4_character,
+        @post_form_step3.day4_farm4_character,
+        @post_form_step3.day5_farm4_character,
+        @post_form_step3.day6_farm4_character,
+        @post_form_step3.day7_farm4_character,
+        @post_form_step3.day8_farm4_character
+      ]
+      # チャプター2畑5の種用
+      session[:chapter2_farm5_seeds] = [
+        @post_form_step3.day1_farm5_seed,
+        @post_form_step3.day2_farm5_seed,
+        @post_form_step3.day3_farm5_seed,
+        @post_form_step3.day4_farm5_seed,
+        @post_form_step3.day5_farm5_seed,
+        @post_form_step3.day6_farm5_seed,
+        @post_form_step3.day7_farm5_seed,
+        @post_form_step3.day8_farm5_seed
+      ]
+      # チャプター2畑5の設置キャラクター用
+      session[:chapter2_farm5_characters] = [
+        @post_form_step3.day1_farm5_character,
+        @post_form_step3.day2_farm5_character,
+        @post_form_step3.day3_farm5_character,
+        @post_form_step3.day4_farm5_character,
+        @post_form_step3.day5_farm5_character,
+        @post_form_step3.day6_farm5_character,
+        @post_form_step3.day7_farm5_character,
+        @post_form_step3.day8_farm5_character
+      ]
+      # チャプター2畑6の種用
+      session[:chapter2_farm6_seeds] = [
+        @post_form_step3.day1_farm6_seed,
+        @post_form_step3.day2_farm6_seed,
+        @post_form_step3.day3_farm6_seed,
+        @post_form_step3.day4_farm6_seed,
+        @post_form_step3.day5_farm6_seed,
+        @post_form_step3.day6_farm6_seed,
+        @post_form_step3.day7_farm6_seed,
+        @post_form_step3.day8_farm6_seed
+      ]
+      # チャプター2畑6の設置キャラクター用
+      session[:chapter2_farm6_characters] = [
+        @post_form_step3.day1_farm6_character,
+        @post_form_step3.day2_farm6_character,
+        @post_form_step3.day3_farm6_character,
+        @post_form_step3.day4_farm6_character,
+        @post_form_step3.day5_farm6_character,
+        @post_form_step3.day6_farm6_character,
+        @post_form_step3.day7_farm6_character,
+        @post_form_step3.day8_farm6_character
+      ]
+      # チャプター2畑7の種用
+      session[:chapter2_farm7_seeds] = [
+        @post_form_step3.day2_farm7_seed,
+        @post_form_step3.day3_farm7_seed,
+        @post_form_step3.day4_farm7_seed,
+        @post_form_step3.day5_farm7_seed,
+        @post_form_step3.day6_farm7_seed,
+        @post_form_step3.day7_farm7_seed,
+        @post_form_step3.day8_farm7_seed
+      ]
+      # チャプター2畑7の設置キャラクター用
+      session[:chapter2_farm7_characters] = [
+        @post_form_step3.day2_farm7_character,
+        @post_form_step3.day3_farm7_character,
+        @post_form_step3.day4_farm7_character,
+        @post_form_step3.day5_farm7_character,
+        @post_form_step3.day6_farm7_character,
+        @post_form_step3.day7_farm7_character,
+        @post_form_step3.day8_farm7_character
+      ]
+      # チャプター2畑8の種用
+      session[:chapter2_farm8_seeds] = [
+        @post_form_step3.day3_farm8_seed,
+        @post_form_step3.day4_farm8_seed,
+        @post_form_step3.day5_farm8_seed,
+        @post_form_step3.day6_farm8_seed,
+        @post_form_step3.day7_farm8_seed,
+        @post_form_step3.day8_farm8_seed
+      ]
+      # チャプター2畑8の設置キャラクター用
+      session[:chapter2_farm8_characters] = [
+        @post_form_step3.day3_farm8_character,
+        @post_form_step3.day4_farm8_character,
+        @post_form_step3.day5_farm8_character,
+        @post_form_step3.day6_farm8_character,
+        @post_form_step3.day7_farm8_character,
+        @post_form_step3.day8_farm8_character
+      ]
+      # チャプター2畑9の種用
+      session[:chapter2_farm9_seeds] = [
+        @post_form_step3.day3_farm9_seed,
+        @post_form_step3.day4_farm9_seed,
+        @post_form_step3.day5_farm9_seed,
+        @post_form_step3.day6_farm9_seed,
+        @post_form_step3.day7_farm9_seed,
+        @post_form_step3.day8_farm9_seed
+      ]
+      # チャプター2畑9の設置キャラクター用
+      session[:chapter2_farm9_characters] = [
+        @post_form_step3.day3_farm9_character,
+        @post_form_step3.day4_farm9_character,
+        @post_form_step3.day5_farm9_character,
+        @post_form_step3.day6_farm9_character,
+        @post_form_step3.day7_farm9_character,
+        @post_form_step3.day8_farm9_character
+      ]
+      redirect_to step4_path, notice: t('.to_third_chapter')
+    else
+      flash.now[:alert] = t('.fail')
+      render :step3, status: :unprocessable_entity
+    end
+  end
 
   def step4
     @post_form_step4 = PostFormStep4.new
+    @now_chapter = Chapter.third
   end
 
   def create_step4
@@ -252,6 +483,181 @@ class PostsController < ApplicationController
       :day8_farm5_seed,
       # 5の畑の設置キャラクター用
       :day8_farm5_character
+    )
+  end
+
+  def post_form_step3_params
+    params.require(:post_form_step3).permit(
+      # 行動選択用
+      :first_day_action,
+      :second_day_action,
+      :third_day_action,
+      :fourth_day_action,
+      :fifth_day_action,
+      :sixth_day_action,
+      :seventh_day_action,
+      :eighth_day_action,
+      # 備考欄用
+      :first_day_remark,
+      :second_day_remark,
+      :third_day_remark,
+      :fourth_day_remark,
+      :fifth_day_remark,
+      :sixth_day_remark,
+      :seventh_day_remark,
+      :eighth_day_remark,
+      # 1の畑の種用
+      :day1_farm1_seed,
+      :day2_farm1_seed,
+      :day3_farm1_seed,
+      :day4_farm1_seed,
+      :day5_farm1_seed,
+      :day6_farm1_seed,
+      :day7_farm1_seed,
+      :day8_farm1_seed,
+      # 1の畑の設置キャラクター用
+      :day1_farm1_character,
+      :day2_farm1_character,
+      :day3_farm1_character,
+      :day4_farm1_character,
+      :day5_farm1_character,
+      :day6_farm1_character,
+      :day7_farm1_character,
+      :day8_farm1_character,
+      # 2の畑の種用
+      :day1_farm2_seed,
+      :day2_farm2_seed,
+      :day3_farm2_seed,
+      :day4_farm2_seed,
+      :day5_farm2_seed,
+      :day6_farm2_seed,
+      :day7_farm2_seed,
+      :day8_farm2_seed,
+      # 2の畑の設置キャラクター用
+      :day1_farm2_character,
+      :day2_farm2_character,
+      :day3_farm2_character,
+      :day4_farm2_character,
+      :day5_farm2_character,
+      :day6_farm2_character,
+      :day7_farm2_character,
+      :day8_farm2_character,
+      # 3の畑の種用
+      :day1_farm3_seed,
+      :day2_farm3_seed,
+      :day3_farm3_seed,
+      :day4_farm3_seed,
+      :day5_farm3_seed,
+      :day6_farm3_seed,
+      :day7_farm3_seed,
+      :day8_farm3_seed,
+      # 3の畑の設置キャラクター用
+      :day1_farm3_character,
+      :day2_farm3_character,
+      :day3_farm3_character,
+      :day4_farm3_character,
+      :day5_farm3_character,
+      :day6_farm3_character,
+      :day7_farm3_character,
+      :day8_farm3_character,
+      # 4の畑の種用
+      :day1_farm4_seed,
+      :day2_farm4_seed,
+      :day3_farm4_seed,
+      :day4_farm4_seed,
+      :day5_farm4_seed,
+      :day6_farm4_seed,
+      :day7_farm4_seed,
+      :day8_farm4_seed,
+      # 4の畑の設置キャラクター用
+      :day1_farm4_character,
+      :day2_farm4_character,
+      :day3_farm4_character,
+      :day4_farm4_character,
+      :day5_farm4_character,
+      :day6_farm4_character,
+      :day7_farm4_character,
+      :day8_farm4_character,
+      # 5の畑の種用
+      :day1_farm5_seed,
+      :day2_farm5_seed,
+      :day3_farm5_seed,
+      :day4_farm5_seed,
+      :day5_farm5_seed,
+      :day6_farm5_seed,
+      :day7_farm5_seed,
+      :day8_farm5_seed,
+      # 5の畑の設置キャラクター用
+      :day1_farm5_character,
+      :day2_farm5_character,
+      :day3_farm5_character,
+      :day4_farm5_character,
+      :day5_farm5_character,
+      :day6_farm5_character,
+      :day7_farm5_character,
+      :day8_farm5_character,
+      # 6の畑の種用
+      :day1_farm6_seed,
+      :day2_farm6_seed,
+      :day3_farm6_seed,
+      :day4_farm6_seed,
+      :day5_farm6_seed,
+      :day6_farm6_seed,
+      :day7_farm6_seed,
+      :day8_farm6_seed,
+      # 6の畑の設置キャラクター用
+      :day1_farm6_character,
+      :day2_farm6_character,
+      :day3_farm6_character,
+      :day4_farm6_character,
+      :day5_farm6_character,
+      :day6_farm6_character,
+      :day7_farm6_character,
+      :day8_farm6_character,
+      # 7の畑の種用
+      :day2_farm7_seed,
+      :day3_farm7_seed,
+      :day4_farm7_seed,
+      :day5_farm7_seed,
+      :day6_farm7_seed,
+      :day7_farm7_seed,
+      :day8_farm7_seed,
+      # 7の畑の設置キャラクター用
+      :day2_farm6_character,
+      :day3_farm6_character,
+      :day4_farm6_character,
+      :day5_farm6_character,
+      :day6_farm6_character,
+      :day7_farm6_character,
+      :day8_farm6_character,
+      # 8の畑の種用
+      :day3_farm8_seed,
+      :day4_farm8_seed,
+      :day5_farm8_seed,
+      :day6_farm8_seed,
+      :day7_farm8_seed,
+      :day8_farm8_seed,
+      # 8の畑の設置キャラクター用
+      :day3_farm8_character,
+      :day4_farm8_character,
+      :day5_farm8_character,
+      :day6_farm8_character,
+      :day7_farm8_character,
+      :day8_farm8_character,
+      # 9の畑の種用
+      :day3_farm9_seed,
+      :day4_farm9_seed,
+      :day5_farm9_seed,
+      :day6_farm9_seed,
+      :day7_farm9_seed,
+      :day8_farm9_seed,
+      # 9の畑の設置キャラクター用
+      :day3_farm9_character,
+      :day4_farm9_character,
+      :day5_farm9_character,
+      :day6_farm9_character,
+      :day7_farm9_character,
+      :day8_farm9_character
     )
   end
 

--- a/app/forms/post_form_step3.rb
+++ b/app/forms/post_form_step3.rb
@@ -1,0 +1,33 @@
+class PostFormStep3
+  include ActiveModel::Model
+
+  attr_accessor :first_day_action, :second_day_action, :third_day_action, :fourth_day_action, :fifth_day_action, :sixth_day_action, :seventh_day_action, :eighth_day_action,
+                :first_day_remark, :second_day_remark, :third_day_remark, :fourth_day_remark, :fifth_day_remark, :sixth_day_remark, :seventh_day_remark, :eighth_day_remark,
+                :day1_farm1_seed, :day2_farm1_seed, :day3_farm1_seed, :day4_farm1_seed, :day5_farm1_seed, :day6_farm1_seed, :day7_farm1_seed, :day8_farm1_seed,
+                :day1_farm1_character, :day2_farm1_character, :day3_farm1_character, :day4_farm1_character, :day5_farm1_character, :day6_farm1_character, :day7_farm1_character, :day8_farm1_character,
+                :day1_farm2_seed, :day2_farm2_seed, :day3_farm2_seed, :day4_farm2_seed, :day5_farm2_seed, :day6_farm2_seed, :day7_farm2_seed, :day8_farm2_seed,
+                :day1_farm2_character, :day2_farm2_character, :day3_farm2_character, :day4_farm2_character, :day5_farm2_character, :day6_farm2_character, :day7_farm2_character, :day8_farm2_character,
+                :day1_farm3_seed, :day2_farm3_seed, :day3_farm3_seed, :day4_farm3_seed, :day5_farm3_seed, :day6_farm3_seed, :day7_farm3_seed, :day8_farm3_seed,
+                :day1_farm3_character, :day2_farm3_character, :day3_farm3_character, :day4_farm3_character, :day5_farm3_character, :day6_farm3_character, :day7_farm3_character, :day8_farm3_character,
+                :day1_farm4_seed, :day2_farm4_seed, :day3_farm4_seed, :day4_farm4_seed, :day5_farm4_seed, :day6_farm4_seed, :day7_farm4_seed, :day8_farm4_seed,
+                :day1_farm4_character, :day2_farm4_character, :day3_farm4_character, :day4_farm4_character, :day5_farm4_character, :day6_farm4_character, :day7_farm4_character, :day8_farm4_character,
+                :day1_farm5_seed, :day2_farm5_seed, :day3_farm5_seed, :day4_farm5_seed, :day5_farm5_seed, :day6_farm5_seed, :day7_farm5_seed, :day8_farm5_seed,
+                :day1_farm5_character, :day2_farm5_character, :day3_farm5_character, :day4_farm5_character, :day5_farm5_character, :day6_farm5_character, :day7_farm5_character, :day8_farm5_character,
+                :day1_farm6_seed, :day2_farm6_seed, :day3_farm6_seed, :day4_farm6_seed, :day5_farm6_seed, :day6_farm6_seed, :day7_farm6_seed, :day8_farm6_seed,
+                :day1_farm6_character, :day2_farm6_character, :day3_farm6_character, :day4_farm6_character, :day5_farm6_character, :day6_farm6_character, :day7_farm6_character, :day8_farm6_character,
+                :day2_farm7_seed, :day3_farm7_seed, :day4_farm7_seed, :day5_farm7_seed, :day6_farm7_seed, :day7_farm7_seed, :day8_farm7_seed,
+                :day2_farm7_character, :day3_farm7_character, :day4_farm7_character, :day5_farm7_character, :day6_farm7_character, :day7_farm7_character, :day8_farm7_character,
+                :day3_farm8_seed, :day4_farm8_seed, :day5_farm8_seed, :day6_farm8_seed, :day7_farm8_seed, :day8_farm8_seed,
+                :day3_farm8_character, :day4_farm8_character, :day5_farm8_character, :day6_farm8_character, :day7_farm8_character, :day8_farm8_character,
+                :day3_farm9_seed, :day4_farm9_seed, :day5_farm9_seed, :day6_farm9_seed, :day7_farm9_seed, :day8_farm9_seed,
+                :day3_farm9_character, :day4_farm9_character, :day5_farm9_character, :day6_farm9_character, :day7_farm9_character, :day8_farm9_character
+
+  validates :first_day_action,    presence: true
+  validates :second_day_action,   presence: true
+  validates :third_day_action,    presence: true
+  validates :fourth_day_action,   presence: true
+  validates :fifth_day_action,    presence: true
+  validates :sixth_day_action,    presence: true
+  validates :seventh_day_action,  presence: true
+  validates :eighth_day_action,   presence: true
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,4 +2,3 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "@fortawesome/fontawesome-free"
-import "./custom/add_remarks_column"

--- a/app/javascript/custom/step2_add_remarks_column.js
+++ b/app/javascript/custom/step2_add_remarks_column.js
@@ -6,13 +6,13 @@ function addRemarksField(turn, fieldName) {
 
 // 備考欄追加ボタンのクリックイベントを設定
 function setupAddRemarksButton(turn, fieldName) {
-  const button = document.querySelector(`.js-add-form-btn${turn}`);
+  const button = document.querySelector(`.js-add-form-btn${turn}-step2`);
   button.addEventListener('click', function() {
     addRemarksField(turn, fieldName);
   });
 }
 
-// 各ターンの備考欄追加ボタンを設定
+// chapter1の各ターンの備考欄追加ボタンを設定
 setupAddRemarksButton(1, 'first_day_remark');
 setupAddRemarksButton(2, 'second_day_remark');
 setupAddRemarksButton(3, 'third_day_remark');

--- a/app/javascript/custom/step3_add_remarks_column.js
+++ b/app/javascript/custom/step3_add_remarks_column.js
@@ -1,0 +1,23 @@
+// 備考欄追加の関数
+function addRemarksField(turn, fieldName) {
+  const remarks = document.querySelector(`.js-remarks-field${turn}`);
+  remarks.innerHTML = `<input type="text" name="post_form_step2[${fieldName}]" id="post_form_step3_${fieldName}" placeholder="備考欄">`;
+}
+
+// 備考欄追加ボタンのクリックイベントを設定
+function setupAddRemarksButton(turn, fieldName) {
+  const button = document.querySelector(`.js-add-form-btn${turn}-step3`);
+  button.addEventListener('click', function() {
+    addRemarksField(turn, fieldName);
+  });
+}
+
+// 各ターンの備考欄追加ボタンを設定
+setupAddRemarksButton(1, 'first_day_remark');
+setupAddRemarksButton(2, 'second_day_remark');
+setupAddRemarksButton(3, 'third_day_remark');
+setupAddRemarksButton(4, 'fourth_day_remark');
+setupAddRemarksButton(5, 'fifth_day_remark');
+setupAddRemarksButton(6, 'sixth_day_remark');
+setupAddRemarksButton(7, 'seventh_day_remark');
+setupAddRemarksButton(8, 'eighth_day_remark');

--- a/app/models/turn.rb
+++ b/app/models/turn.rb
@@ -3,4 +3,15 @@ class Turn < ApplicationRecord
   has_many :chapters, through: :chapter_turns
 
   validates :turn_number, presence: true, uniqueness: true
+
+  def add_to_turn_number(chapter_number)
+    case chapter_number
+      when 2 then
+        self.turn_number += 8
+      when 3 then
+        self.turn_number += 16
+      when 4 then
+        self.turn_number += 24
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,7 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <%= yield(:js) %>
   </head>
 
   <body>

--- a/app/views/posts/step2.html.erb
+++ b/app/views/posts/step2.html.erb
@@ -1,3 +1,6 @@
+<% content_for :js do %>
+  <%= javascript_import_module_tag "custom/step2_add_remarks_column" %>
+<% end %>
 <%= render 'selected_characters', selected_support_characters: @selected_support_characters %>
 <%= render 'now_chapter', now_chapter: @now_chapter %>
 <%= form_with model: @post_form_step2, url: create_step2_path, local: true do |f| %>
@@ -26,7 +29,7 @@
                 <%= f.collection_select "#{day}", @actions, :id, :content, { prompt: t('.action_choice') } %>
               </div>
               <div class="js-remarks-field<%= index %>">
-                <button type="button" class="js-add-form-btn<%= index %>"><%= t('.add_remark') %></button>
+                <button type="button" class="js-add-form-btn<%= index %>-step2"><%= t('.add_remark') %></button>
               </div>
             </td>
           <% end %>

--- a/app/views/posts/step3.html.erb
+++ b/app/views/posts/step3.html.erb
@@ -1,7 +1,257 @@
-<% session[:chapter1_actions].each do |action| %>
-  <p><%= Action.find(action).content %></p>
+<% content_for :js do %>
+  <%= javascript_import_module_tag "custom/step3_add_remarks_column" %>
 <% end %>
-
-<% @selected_chapter1_remarks.each do |remark| %>
-  <p><%= remark %></p>
+<%= render 'selected_characters', selected_support_characters: @selected_support_characters %>
+<%= render 'now_chapter', now_chapter: @now_chapter %>
+<%= form_with model: @post_form_step3, url: create_step3_path, local: true do |f| %>
+  <%= render 'shared/error_messages', object: f.object %>
+  <div class="mt-6 flex justify-center">
+    <table>
+      <thead>
+        <tr class="border border-black">
+          <%# 空欄のマスが必要なため空のthを追加 %>
+          <th colspan="2"></th>
+          <% @turns.each do |turn| %>
+            <th class="border border-black">
+              <%= turn.add_to_turn_number(@now_chapter.chapter_number).to_s + t('defaults.day') %>
+            </th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody class="border border-black">
+        <tr>
+          <td colspan="2" class="border border-black"></td>
+          <%# 9日〜16日までの行動選択用 %>
+          <% days = [:first_day_action, :second_day_action, :third_day_action, :fourth_day_action, :fifth_day_action, :sixth_day_action, :seventh_day_action, :eighth_day_action] %>
+          <% days.each.with_index(1) do |day, index| %>
+            <td class="border border-black">
+              <div>
+                <%= f.collection_select "#{day}", @actions, :id, :content, { prompt: t('.action_choice') } %>
+              </div>
+              <div class="js-remarks-field<%= index %>">
+                <button type="button" class="js-add-form-btn<%= index %>-step3"><%= t('.add_remark') %></button>
+              </div>
+            </td>
+          <% end %>
+        </tr>
+        <% @farm_places.each do |farm_place| %>
+          <% case farm_place.farm_number %>
+            <%# 1の畑の場合 %>
+            <% when @farm_places.first.farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td rowspan="18" class="border border-black"><%= FarmPlace.model_name.human %></td>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm1_seeds = [:day1_farm1_seed, :day2_farm1_seed, :day3_farm1_seed, :day4_farm1_seed, :day5_farm1_seed, :day6_farm1_seed, :day7_farm1_seed, :day8_farm1_seed] %>
+                <% farm1_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm1_characters = [:day1_farm1_character, :day2_farm1_character, :day3_farm1_character, :day4_farm1_character, :day5_farm1_character, :day6_farm1_character, :day7_farm1_character, :day8_farm1_character] %>
+                <% farm1_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 2の畑の場合 %>
+            <% when @farm_places.second.farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm2_seeds = [:day1_farm2_seed, :day2_farm2_seed, :day3_farm2_seed, :day4_farm2_seed, :day5_farm2_seed, :day6_farm2_seed, :day7_farm2_seed, :day8_farm2_seed] %>
+                <% farm2_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm2_characters = [:day1_farm2_character, :day2_farm2_character, :day3_farm2_character, :day4_farm2_character, :day5_farm2_character, :day6_farm2_character, :day7_farm2_character, :day8_farm2_character] %>
+                <% farm2_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 3の畑の場合 %>
+            <% when @farm_places.third.farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm3_seeds = [:day1_farm3_seed, :day2_farm3_seed, :day3_farm3_seed, :day4_farm3_seed, :day5_farm3_seed, :day6_farm3_seed, :day7_farm3_seed, :day8_farm3_seed] %>
+                <% farm3_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm3_characters = [:day1_farm3_character, :day2_farm3_character, :day3_farm3_character, :day4_farm3_character, :day5_farm3_character, :day6_farm3_character, :day7_farm3_character, :day8_farm3_character] %>
+                <% farm3_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 4の畑の場合 %>
+            <% when @farm_places.fourth.farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm4_seeds = [:day1_farm4_seed, :day2_farm4_seed, :day3_farm4_seed, :day4_farm4_seed, :day5_farm4_seed, :day6_farm4_seed, :day7_farm4_seed, :day8_farm4_seed] %>
+                <% farm4_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm4_characters = [:day1_farm4_character, :day2_farm4_character, :day3_farm4_character, :day4_farm4_character, :day5_farm4_character, :day6_farm4_character, :day7_farm4_character, :day8_farm4_character] %>
+                <% farm4_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 5の畑の場合 %>
+            <% when @farm_places.fifth.farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm5_seeds = [:day1_farm5_seed, :day2_farm5_seed, :day3_farm5_seed, :day4_farm5_seed, :day5_farm5_seed, :day6_farm5_seed, :day7_farm5_seed, :day8_farm5_seed] %>
+                <% farm5_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm5_characters = [:day1_farm5_character, :day2_farm5_character, :day3_farm5_character, :day4_farm5_character, :day5_farm5_character, :day6_farm5_character, :day7_farm5_character, :day8_farm5_character] %>
+                <% farm5_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 6の畑の場合 %>
+            <% when @farm_places[5].farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <% farm6_seeds = [:day1_farm6_seed, :day2_farm6_seed, :day3_farm6_seed, :day4_farm6_seed, :day5_farm6_seed, :day6_farm6_seed, :day7_farm6_seed, :day8_farm6_seed] %>
+                <% farm6_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <% farm6_characters = [:day1_farm6_character, :day2_farm6_character, :day3_farm6_character, :day4_farm6_character, :day5_farm6_character, :day6_farm6_character, :day7_farm6_character, :day8_farm6_character] %>
+                <% farm6_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 7の畑の場合 %>
+            <% when @farm_places[6].farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm7_seeds = [:day2_farm7_seed, :day3_farm7_seed, :day4_farm7_seed, :day5_farm7_seed, :day6_farm7_seed, :day7_farm7_seed, :day8_farm7_seed] %>
+                <% farm7_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm7_characters = [:day2_farm7_character, :day3_farm7_character, :day4_farm7_character, :day5_farm7_character, :day6_farm7_character, :day7_farm7_character, :day8_farm7_character] %>
+                <% farm7_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 8の畑の場合 %>
+            <% when @farm_places[7].farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm8_seeds = [:day3_farm8_seed, :day4_farm8_seed, :day5_farm8_seed, :day6_farm8_seed, :day7_farm8_seed, :day8_farm8_seed] %>
+                <% farm8_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm8_characters = [:day3_farm8_character, :day4_farm8_character, :day5_farm8_character, :day6_farm8_character, :day7_farm8_character, :day8_farm8_character] %>
+                <% farm8_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+            <%# 9の畑の場合 %>
+            <% when @farm_places[8].farm_number then %>
+              <%# 種設置用 %>
+              <tr>
+                <td class="border border-black"><%= farm_place.farm_number.to_s + t('defaults.of_farm') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm9_seeds = [:day3_farm9_seed, :day4_farm9_seed, :day5_farm9_seed, :day6_farm9_seed, :day7_farm9_seed, :day8_farm9_seed] %>
+                <% farm9_seeds.each do |seed| %>
+                  <td class="border border-black">
+                    <%= f.collection_select seed, @flower_seeds, :id, :name, { prompt: t('.seed_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+              <%# キャラクター設置用 %>
+              <tr>
+                <td class="border border-black"><%= t('defaults.set_character') %></td>
+                <td class="border border-black bg-slate-400"></td>
+                <td class="border border-black bg-slate-400"></td>
+                <% farm9_characters = [:day3_farm9_character, :day4_farm9_character, :day5_farm9_character, :day6_farm9_character, :day7_farm9_character, :day8_farm9_character] %>
+                <% farm9_characters.each do |character| %>
+                  <td class="border border-black">
+                    <%= f.collection_select character, @selected_support_characters, :id, :name, { prompt: t('.character_choice') } %>
+                  </td>
+                <% end %>
+              </tr>
+          <% end %>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+  <div class="flex justify-between mt-8 mr-32 mb-8 ml-32">
+    <%= link_to (t '.return_step'), step3_path, class: 'rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-center text-sm font-medium text-gray-700 shadow-sm transition-all hover:bg-gray-100 focus:ring focus:ring-gray-100 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400' %>
+    <%= f.submit (t '.next_step'), class: 'rounded-lg border border-gray-300 bg-white px-5 py-2.5 text-center text-sm font-medium text-gray-700 shadow-sm transition-all hover:bg-gray-100 focus:ring focus:ring-gray-100 disabled:cursor-not-allowed disabled:border-gray-100 disabled:bg-gray-50 disabled:text-gray-400' %>
+  </div>
 <% end %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,4 +6,5 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "@fortawesome/fontawesome-free", to: "https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.2.0/js/all.js"
-pin_all_from "app/javascriot/custom", under: "custom"
+pin "custom/step2_add_remarks_column"
+pin "custom/step3_add_remarks_column"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -48,3 +48,12 @@ ja:
         sixth_day_action: '6日目の行動'
         seventh_day_action: '7日目の行動'
         eighth_day_action: '8日目の行動'
+      post_form_step3:
+        first_day_action: '9日目の行動'
+        second_day_action: '10日目の行動'
+        third_day_action: '11日目の行動'
+        fourth_day_action: '12日目の行動'
+        fifth_day_action: '13日目の行動'
+        sixth_day_action: '14日目の行動'
+        seventh_day_action: '15日目の行動'
+        eighth_day_action: '16日目の行動'

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -52,3 +52,13 @@ ja:
     create_step2:
       to_second_chapter: '2の巻の内容を入力してください'
       fail: '入力し直してください'
+    step3:
+      action_choice: '行動選択'
+      add_remark: '備考欄追加'
+      seed_choice: '種選択'
+      character_choice: 'キャラクター選択'
+      return_step: '戻る'
+      next_step: '次へ'
+    create_step3:
+      to_third_chapter: '3の巻の内容を入力してください'
+      fail: '入力し直してください'


### PR DESCRIPTION
### 概要
新規投稿ステップ3の入力フォーム。チャプター2の各日にちの行動、備考欄、畑、設置キャラクター、選択ができる。
各日にちの行動選択を入力していないと次のステップには進めないようになっています。javascriptのファイルを特定のページのみで反映させるように修正しました。
### 確認方法
各日にちの行動選択を選ばずに次へを押すと、再度入力画面に戻るようになっています。
### コメント
renderで画面が再表示されたらクリックイベントが発火しない。turbolinkをfalseにするとリロードしなくても機能するみたいだが上手くいかないため一旦保留します。
### 対象issue
close #19