### PR TITLE
[add]sessionの管理をRedisを使用するように追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@
 !/app/assets/builds/.keep
 
 .env.production
+dump.rdb

--- a/Gemfile
+++ b/Gemfile
@@ -93,3 +93,5 @@ gem "sentry-rails", "~> 5.10"
 gem "sorcery"
 # 日本語化のため
 gem "rails-i18n"
+# Redis利用のため
+gem "redis-actionpack"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     concurrent-ruby (1.2.2)
+    connection_pool (2.4.1)
     crass (1.0.6)
     date (3.3.3)
     debug (1.8.0)
@@ -213,6 +214,19 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    redis (5.0.8)
+      redis-client (>= 0.17.0)
+    redis-actionpack (5.3.0)
+      actionpack (>= 5, < 8)
+      redis-rack (>= 2.1.0, < 3)
+      redis-store (>= 1.1.0, < 2)
+    redis-client (0.18.0)
+      connection_pool
+    redis-rack (2.1.4)
+      rack (>= 2.0.8, < 3)
+      redis-store (>= 1.2, < 2)
+    redis-store (1.10.0)
+      redis (>= 4, < 6)
     regexp_parser (2.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
@@ -337,6 +351,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.7)
   rails-i18n
+  redis-actionpack
   rspec-rails
   rubocop
   rubocop-performance

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,0 +1,5 @@
+Rails.application.config.session_store :redis_store, expire_after: 1.day, servers: {
+  host: "localhost",
+  port: 6379,
+  namespace: "user_sessions"
+}


### PR DESCRIPTION
### 概要
sessionの管理をRedisを使用する方法に変更しました。デフォルトのままだとsessionに保持しておく内容の上限を超えてしまったための変更です。

### 確認方法
gemを追加したので、bundle installを実行してください。
新規投稿ページでフォームの内容をsessionに一時保存しているので、検証ツールでsession_idだけの管理になっていることを確認してください。

### issue
close #68 

### コメント
Redisのキャッチアップが全然できていないため不備が多々あると思います。