### PR TITLE
[fix]fly.ioのRedisに接続できるように変更

### DIFF
--- a/config/dockerfile.yml
+++ b/config/dockerfile.yml
@@ -6,4 +6,5 @@ options:
     fly_launch_runtime: rails
   postgresql: true
   prepare: false
+  redis: true
   sentry: true

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,5 +1,6 @@
 Rails.application.config.session_store :redis_store, expire_after: 1.day, servers: {
-  host: "localhost",
+  host: "fly-kamutora-farm-redis.upstash.io",
   port: 6379,
+  password: "f4fbc6c43a30474786123aa2fd0877dd",
   namespace: "user_sessions"
 }

--- a/fly.toml
+++ b/fly.toml
@@ -1,9 +1,9 @@
-# fly.toml app configuration file generated for kamutora on 2023-09-21T08:05:04+09:00
+# fly.toml app configuration file generated for kamutora-farm on 2023-11-21T00:43:12+09:00
 #
 # See https://fly.io/docs/reference/configuration/ for information about how to use this file.
 #
 
-app = "kamutora"
+app = "kamutora-farm"
 primary_region = "nrt"
 console_command = "/rails/bin/rails console"
 


### PR DESCRIPTION
### 概要
fly.ioでRedisを利用できるようにしました。RedisのURLをfly.ioで利用できるように変更しました。

### コメント
fly.ioでデプロイしたのですが、データベースの容量を多く使っているわけでは無いはずなのに料金が発生してしまいました。そのままにしておくと時間経過だけで料金が増えているみたいなので一旦データベースは削除してあります。